### PR TITLE
Bug/2/goneri

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -182,6 +182,7 @@ packages=(
         openvswitch-datapath-dkms \
         pacemaker \
         pm-utils \
+        python-swiftclient \
         rabbitmq-server \
         rsync \
         ruby-activerecord \
@@ -244,6 +245,7 @@ packages=(
         python-cinderclient \
         python-kombu \
         python-memcached \
+        python-swiftclient \
         rabbitmq-server \
         rsync \
         xfsprogs \


### PR DESCRIPTION
This pull request add neutron-plugin-linuxbridge-agent and python-swiftclient.

The first one is to offer an alternative to OVS, especially on LXC. The second is a dependency for puppet-swift.
