### PR TITLE
puppet-master: Add kwalify as dependency

### DIFF
--- a/puppet-master.install
+++ b/puppet-master.install
@@ -49,14 +49,15 @@ EOF
 	    do_chroot ${dir} dpkg -i puppetlabs-release-$RELEASE.deb
 	    do_chroot ${dir} rm puppetlabs-release-$RELEASE.deb
 	    do_chroot ${dir} apt-get update
-	    PACKAGES="puppetmaster puppetmaster-passenger puppet augeas-tools git ntp puppetdb puppetdb-terminus"
+	    PACKAGES="puppetmaster puppetmaster-passenger puppet augeas-tools git ntp puppetdb puppetdb-terminus kwalify"
 	    install_packages $dir $PACKAGES
 	    do_chroot ${dir} a2dissite puppetmaster
 	    ;;
 	"CentOS"|"RedHatEnterpriseServer")
 	    if [ "$(get_redhat_major_version $CODENAME)" == "6" ]; then
 		add_puppet_repository $DIST $dir
-		install_packages $dir puppet-server git augeas ntp httpd puppetdb puppetdb-terminus
+		add_epel_repository $dir
+		install_packages $dir puppet-server git augeas ntp httpd puppetdb puppetdb-terminus rubygem-kwalify
 		remove_puppet_repository $dir
 	    fi
 	    ;;


### PR DESCRIPTION
In order to validate the site.pp manifest we now rely on kwalify.
