### PR TITLE
openstack-common: Specifcy the distribtuin for removing puppet repositor...

### DIFF
--- a/openstack-common.install
+++ b/openstack-common.install
@@ -39,7 +39,7 @@ setup_puppet_rpm() {
     local dir=$1
     add_puppet_repository $DIST $dir
     install_packages $dir puppet
-    remove_puppet_repository $dir
+    remove_puppet_repository $DIST $dir
 }
 
 prepare_packages () {


### PR DESCRIPTION
...ies

Currently, the call to remove_puppet_repository does not work because the
function expects to receive two parameters buts only receives one.
