### PR TITLE
openstack-full: Remove repo that points to os-ci-admin (enovance)

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -301,6 +301,9 @@ case "$OS" in
         do_chroot $dir chkconfig puppet on
 
         do_chroot $dir rpm -qv ${packages[$(package_type)]} || fatal_error "Some packages are not installed"
+
+        do_chroot $dir rm /etc/yum.repos.d/osp4.repo
+
     ;;
     *)
     fatal_error "OS or Release not supported"


### PR DESCRIPTION
This commit remove the repos that points to eNovance internals stuff.
The image should be able to be deployed/distribute anywhere.
