### PR TITLE
Add hdparm to the package list

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -169,6 +169,7 @@ packages=(
         galera \
         glance \
         haproxy \
+        hdparm \
         heat-api \
         heat-api-cfn \
         heat-api-cloudwatch \
@@ -227,6 +228,7 @@ packages=(
         corosync \
         galera \
         haproxy \
+        hdparm \
         httpd \
         keepalived \
         memcached \


### PR DESCRIPTION
Ceph needs hdparm to disable the writeback cache from the disks.

Closes bug: #17
