### PR TITLE
openstack-full role on Debian must use kernel 3.12 from bpo for OVS 2.0.1 to work properly

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -143,7 +143,7 @@ EOF
 esac
 
 if [ "$OS" = Debian ]; then
-    headers=linux-headers-3.2.0-4-all-amd64
+    headers=linux-headers-3.12-0.bpo.1-amd64
 else
     headers=
 fi
@@ -284,7 +284,8 @@ update_repositories $dir
 
 case "$OS" in
     "Debian")
-        install_packages_disabled $dir -t wheezy-backports qemu-kvm nova-compute-kvm
+        install_packages_disabled $dir -t wheezy-backports qemu-kvm nova-compute-kvm initramfs-tools
+        install_packages_disabled $dir -t wheezy-backports linux-image-3.12-0.bpo.1-amd64
     ;&
     "Debian"|"Ubuntu")
         install_packages_disabled $dir ${packages[$(package_type)]}


### PR DESCRIPTION
Issue met with @EmilienM and discussed with @fredericlepied ; GRE tunnels are not mounted if this configuration is not met.

The trick is to install initramfs-tools from wheezy-backports prior to the 3.12 kernel. The role is building correctly in my eDeploy server, and this setup is working well in a Debian 7 platform for now.
