### PR TITLE
build eDeploy roles for each commit on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: bash
+
+before_script:
+    - sudo apt-get install update
+    - sudo apt-get install -y make debootstrap
+    - mkdir build archive
+script:
+    - export ROLES="openstack-common openstack-full puppet-master install-server ceph"
+    - sudo make TOP=build ARCHIVE=archive DIST=precise DVER=U12.04 openstack-full
+    - sudo make TOP=build ARCHIVE=archive DIST=wheezy DVER=D7 openstack-full


### PR DESCRIPTION
Use travis-ci.org service to build eDeploy roles for each pull request
and commit.
It will avoid any eDeploy role build failure when making a commit in
scripts.
