### PR TITLE
openstack-full: Prepare upgrade to 1.2.0

### DIFF
--- a/upgrade/H.1.1.0/openstack-full/H.1.2.0/README.md
+++ b/upgrade/H.1.1.0/openstack-full/H.1.2.0/README.md
@@ -1,0 +1,4 @@
+upgrade-openstack-ansible
+=========================
+
+Ansible playbook for upgrading H.1.1.0 to H.1.2.0 releases.

--- a/upgrade/H.1.1.0/openstack-full/H.1.2.0/group_vars/all
+++ b/upgrade/H.1.1.0/openstack-full/H.1.2.0/group_vars/all
@@ -1,0 +1,9 @@
+---
+# Variables here are applicable to all host groups NOT roles
+
+# Last product release code
+version: D7-H.1.2.0
+os_username: admin
+os_tenant_name: admin
+os_password: secrete
+os_auth_url: "http://controller.enovance.com:5000/v2.0"

--- a/upgrade/H.1.1.0/openstack-full/H.1.2.0/hosts
+++ b/upgrade/H.1.1.0/openstack-full/H.1.2.0/hosts
@@ -1,0 +1,11 @@
+# file: hosts
+
+[controllers]
+controller.enovance.com
+
+[computes]
+compute.enovance.com
+
+[networks]
+network.enovance.com
+

--- a/upgrade/H.1.1.0/openstack-full/H.1.2.0/roles/compute/tasks/main.yml
+++ b/upgrade/H.1.1.0/openstack-full/H.1.2.0/roles/compute/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# file: roles/common/tasks/main.yml
+
+- name: edeploy upgrade
+  edeploy: command=upgrade version={{ version }}
+  tags: before_config
+
+# This release upgrades Havana 2 to Havana 3
+# Some services need to be restarted
+- name: restart openstack
+  service: name={{ item }} state=restarted
+  with_items:
+    - nova-compute
+    - ceilometer-agent-compute
+    - neutron-plugin-openvswitch-agent
+  tags: before_config

--- a/upgrade/H.1.1.0/openstack-full/H.1.2.0/roles/controller/tasks/main.yml
+++ b/upgrade/H.1.1.0/openstack-full/H.1.2.0/roles/controller/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+# file: roles/common/tasks/main.yml
+
+- name: edeploy upgrade
+  edeploy: command=upgrade version={{ version }}
+  tags: before_config
+
+# This release upgrades Havana 2 to Havana 3
+# Some services need to be restarted
+- name: restart openstack
+  service: name={{ item }} state=restarted
+  with_items:
+    - ceilometer-api
+    - ceilometer-collector
+    - ceilometer-alarm-evaluator
+    - ceilometer-alarm-notifier
+    - cinder-api
+    - cinder-scheduler
+    - cinder-volume
+    - cinder-backup
+    - glance-api
+    - glance-registry
+    - apache2
+    - heat-api
+    - heat-api-cfn
+    - heat-api-cloudwatch
+    - keystone
+    - neutron-server
+    - nova-api
+    - nova-cert
+    - nova-conductor
+    - nova-consoleauth
+    - nova-scheduler
+    - nova-spicehtml5proxy
+  tags: before_config
+
+- name: restart services managed by Corosync
+  shell: crm resource restart {{ item }}
+  with_items:
+    - heat-engine
+    - ceilometer-agent-central
+  tags: before_config
+  when: inventory_hostname == groups['controllers'][-1]

--- a/upgrade/H.1.1.0/openstack-full/H.1.2.0/roles/loadbalancer/tasks/main.yml
+++ b/upgrade/H.1.1.0/openstack-full/H.1.2.0/roles/loadbalancer/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+# file: main.yml
+
+- name: edeploy upgrade
+  edeploy: command=upgrade version={{ version }}
+  tags: before_config

--- a/upgrade/H.1.1.0/openstack-full/H.1.2.0/roles/network/tasks/main.yml
+++ b/upgrade/H.1.1.0/openstack-full/H.1.2.0/roles/network/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+# file: roles/common/tasks/main.yml
+
+- name: edeploy upgrade
+  edeploy: command=upgrade version={{ version }}
+  tags: before_config
+
+# This release upgrades Havana 2 to Havana 3
+# Some services need to be restarted
+- name: restart openstack
+  service: name={{ item }} state=restarted
+  with_items:
+    - neutron-plugin-openvswitch-agent
+  tags: before_config

--- a/upgrade/H.1.1.0/openstack-full/H.1.2.0/site.yml
+++ b/upgrade/H.1.1.0/openstack-full/H.1.2.0/site.yml
@@ -1,0 +1,22 @@
+---
+# file: site.yml
+
+- hosts: all
+  user: jenkins
+  sudo: true
+
+- hosts: controllers
+  roles:
+    - controller
+
+- hosts: loadbalancers
+  roles:
+    - loadbalancer
+
+- hosts: computes
+  roles:
+    - compute
+
+- hosts: networks
+  roles:
+    - network


### PR DESCRIPTION
- Add network node type
- Run eDeploy to upgrade to 1.2.0 role version
- Restart OpenStack services updated in Havana 3
