### PR TITLE
openstack-full/debian: install neutron-l3-healthcheck

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -194,6 +194,7 @@ packages=(
         mysql-client \
         neutron-dhcp-agent \
         neutron-l3-agent \
+        neutron-l3-healthcheck \
         neutron-lbaas-agent \
         neutron-metadata-agent \
         neutron-metering-agent \


### PR DESCRIPTION
neutron-l3-healthcheck is a tool written by eNovance to bring Neutron L3
Agent highly available.
