### PR TITLE
install-server: install pycrypto from pypi

### DIFF
--- a/install-server.install
+++ b/install-server.install
@@ -33,8 +33,12 @@ install_packages_disabled $dir dnsmasq
 # Ansible
 
 case "$OS" in
-    "Debian"|"Ubuntu")
+    "Debian")
 	install_packages $dir python-jinja2 python-paramiko
+	do_chroot $dir pip install ansible
+	;;
+    "Ubuntu")
+	install_packages $dir python-jinja2 python-paramiko build-essential
 	do_chroot $dir pip install ansible
 	;;
     "CentOS"|"RedHatEnterpriseServer")


### PR DESCRIPTION
pycrypto from Ubuntu is too old, we need >= 2.6 release.
