### PR TITLE
I.1.0.0: Migrate instances during compute upgrades

### DIFF
--- a/upgrade/H.1.3.0/openstack-full/I.1.0.0/roles/compute/files/migrate.sh
+++ b/upgrade/H.1.3.0/openstack-full/I.1.0.0/roles/compute/files/migrate.sh
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2014 eNovance SAS <licensing@enovance.com>
+#
+# Author: Emilien Macchi <emilien.macchi@enovance.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Migrate all instances from a compute server before upgrade
+
+set -e
+set -x
+
+COMPUTE=$1
+OS_USERNAME=$2
+OS_TENANT_NAME=$3
+OS_PASSWORD=$4
+OS_AUTH_URL=$5
+
+if [ -z "$COMPUTE" ]; then
+  echo "You have to provide the compute hostname as a parameter."
+  exit 1
+fi
+
+# Extract all VMs hosted on this compute node
+VMS=$(nova-manage --nodebug vm list | grep $COMPUTE | awk '{print $1')
+
+# Migrate all VM on another compute node
+for VM in $VMS; do
+  echo "Instance $VM is going to be migrated:"
+  nova live-migration $VM
+
+  # test if the migration worked and the VM is still alive.
+  if ! timeout 20 sh -c "while ! nova show $VM | grep status | grep -q ACTIVE; do sleep 1; done"; then
+    echo "Instance $VM has failed to be migrated and is not active."
+    exit 1
+  fi
+  if ! timeout 20  sh -c "while ! nova-manage --nodebug vm list | grep $COMPUTE | grep $VM; do sleep 1; done"; then
+    echo "Instance $VM has failed to be migrated but is still active."
+  else
+    echo "Instance $VM has been successfully migrated and is active."
+  fi
+done
+
+echo "All the instances have been migrated from $COMPUTE server."
+nova-manage service disable nova-compute $COMPUTE
+echo "This compute is now not able to host a VM"

--- a/upgrade/H.1.3.0/openstack-full/I.1.0.0/roles/compute/tasks/main.yml
+++ b/upgrade/H.1.3.0/openstack-full/I.1.0.0/roles/compute/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # file: roles/compute/tasks/main.yml
 
+# migrate instances
+- name: migrate instances
+  script: migrate.sh {{ ansible_hostname }} {{ os_username }} {{ os_tenant_name }} {{ os_password }} {{ os_auth_url }}
+  tags: before_config
+
 # Stop Services
 - name: stop services before upgrade
   service: name={{ item }} state=stopped


### PR DESCRIPTION
When upgrading compute nodes, migrate VMs hosted on the compute to
another compute randomly and ensure the VM is migrated before running
the upgrade.
It avoid to have downtime during the upgrade to Icehouse.
