### PR TITLE
install-server: Pin rspec (rspec-core) to < 2.99

### DIFF
--- a/install-server.install
+++ b/install-server.install
@@ -64,11 +64,15 @@ case "$OS" in
 	add_epel_repository $DIST
 	install_packages $dir rubygems
 	remove_epel_repository $DIST
-        do_chroot $dir gem install --no-ri --no-rdoc -v 2.99.0 rspec-core
+        do_chroot $dir gem install --no-ri --no-rdoc -v '< 2.99' rspec
 	;;
     "CentOS")
 	install_packages $dir rubygems
+        do_chroot $dir gem install --no-ri --no-rdoc -v '< 2.99' rspec
 	;;
+    "Debian"|"Ubuntu")
+        do_chroot $dir gem install --no-ri --no-rdoc -v '< 2.99' rspec
+        ;;
 esac
 
 do_chroot $dir gem install --no-ri --no-rdoc --no-prerelease serverspec r10k rspec-extra-formatters


### PR DESCRIPTION
Pin to rspec < 2.99 until rspec-puppet and serverspec officially
supports rspec 3.x.  This is to avoid warnings due to deprecated
matchers in the rspec-puppet and JUnitFormatter gem.
