### PR TITLE
*: Avoiding implicit parameters on rhn calls

### DIFF
--- a/cloud.install
+++ b/cloud.install
@@ -62,9 +62,9 @@ EOF
                 7)
                   # Attach to the pool "Red Hat Enterprise Linux OpenStack
                   # Platform (Physical)"
-                  attach_pool_rh_cdn $RHN_CDN_POOL_ID
-                  add_rh_cdn_repo rhel-7-server-rpms
-                  add_rh_cdn_repo rhel-7-server-rh-common-rpms
+                  attach_pool_rh_cdn $dir $RHN_CDN_POOL_ID
+                  add_rh_cdn_repo $dir rhel-7-server-rpms
+                  add_rh_cdn_repo $dir rhel-7-server-rh-common-rpms
                   # TODO(EmilienM) cloud-init is not in rhel-7-server-rh-common-rpms now
                   # install_packages $dir "cloud-init"
                   ;;

--- a/openstack-common.install
+++ b/openstack-common.install
@@ -70,9 +70,9 @@ EOF
                   ;;
                 7)
                   # Attach to the pool "Red Hat Enterprise Linux OpenStack Platform (Physical)"
-                  attach_pool_rh_cdn $RHN_CDN_POOL_ID
-                  add_rh_cdn_repo rhel-7-server-openstack-5.0-rpms
-                  add_rh_cdn_repo rhel-7-server-rpms
+                  attach_pool_rh_cdn $dir $RHN_CDN_POOL_ID
+                  add_rh_cdn_repo $dir rhel-7-server-openstack-5.0-rpms
+                  add_rh_cdn_repo $dir rhel-7-server-rpms
                   ;;
             esac
             install_packages $dir puppet facter hiera

--- a/openstack-full.install
+++ b/openstack-full.install
@@ -441,13 +441,13 @@ case "$OS" in
               ;;
             7)
               # Attach to the pool "Red Hat Enterprise Linux OpenStack Platform (Physical)"
-              attach_pool_rh_cdn $RHN_CDN_POOL_ID
+              attach_pool_rh_cdn $dir $RHN_CDN_POOL_ID
       
               # Red Hat OpenStack 5
-              add_rh_cdn_repo rhel-7-server-openstack-5.0-rpms
+              add_rh_cdn_repo $dir rhel-7-server-openstack-5.0-rpms
       
               # pacemaker is in RHEL Server High Availability (v.7 for 64-bit x86_64)
-              add_rh_cdn_repo rhel-ha-for-rhel-7-server-rpms
+              add_rh_cdn_repo $dir rhel-ha-for-rhel-7-server-rpms
               ;;
         esac
 


### PR DESCRIPTION
Having implicit parameters is always a little bit dangerous. Let's make
the $dir explicit instead of implicit.

To be merged simultaneously with fix_options on edeploy.
