### PR TITLE
Add reverse-proxy-auth plugin for Jenkins

### DIFF
--- a/jenkins.install
+++ b/jenkins.install
@@ -56,7 +56,9 @@ JENKINS_PLUGINS="ssh-agent/1.4.1/ssh-agent.hpi \
                  token-macro/1.10/token-macro.hpi \
                  multiple-scms/0.3/multiple-scms.hpi \
                  ansicolor/0.4.0/ansicolor.hpi \
-                 git/2.2.1/git.hpi"
+                 git/2.2.1/git.hpi \
+                 reverse-proxy-auth-plugin/1.4.0/reverse-proxy-auth-plugin.hpi"
+
 JENKINS_CACHE=${JENKINS_CACHE:=${dir}/../../jenkins-plugins-cache}
 
 update_repositories $dir


### PR DESCRIPTION
This plugins makes it possible to use a SSO solution for
Jenkins. Documentation for the plugin is available at:

https://wiki.jenkins-ci.org/display/JENKINS/Reverse+Proxy+Auth+Plugin
