### PR TITLE
openstack-full: manage ICE for Red Hat

### DIFF
--- a/openstack-common.install
+++ b/openstack-common.install
@@ -73,7 +73,7 @@ EOF
                 # for augeas
                 add_rh_cdn_repo $dir rhel-7-server-optional-rpms
             fi
-            install_packages $dir puppet facter hiera augeas
+            install_packages $dir puppet facter hiera augeas yum-plugin-priorities
             remove_puppet_repository $DIST
             ;;
         *)

--- a/openstack-full.install
+++ b/openstack-full.install
@@ -33,6 +33,10 @@ if [ -z "$OS_VERS" ]; then
     OS_VERS=icehouse
 fi
 
+# Specify the ICE (Ceph for Enterprise) release
+# 1.2 = firefly
+ICE_RELEASE=1.2
+
 install_ib_if_needed $ORIG $dir
 
 function build_dkms() {
@@ -127,23 +131,6 @@ baseurl=http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/
 gpgcheck=0
 enabled=1
 EOF
-        cat > ${dir}/etc/yum.repos.d/ceph.repo <<EOF
-[ceph-noarch]
-name=Ceph packages for $basearch
-baseurl=http://ceph.com/rpm/rhel$CODENAME_MAJOR/noarch/
-enabled=1
-gpgcheck=1
-type=rpm-md
-gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
-
-[ceph]
-name=Ceph packages for $basearch
-baseurl=http://ceph.com/rpm/rhel$CODENAME_MAJOR/x86_64/
-enabled=1
-gpgcheck=1
-type=rpm-md
-gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
-EOF
         if [ "$CODENAME_MAJOR" == "6" ]; then
             cat > ${dir}/etc/yum.repos.d/mariadb.repo <<EOF
 # MariaDB 5.5 RedHat repository list - created 2013-12-17 16:18 UTC
@@ -156,7 +143,6 @@ gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1
 EOF
             cat >> ${dir}/etc/yum.repos.d/ceph.repo <<EOF
-
 [ceph-extras]
 name=Ceph Extras
 baseurl=http://ceph.com/packages/ceph-extras/rpm/rhel6.5/x86_64/
@@ -193,8 +179,6 @@ os_packages=(
         ceilometer-api \
         ceilometer-collector \
         ceilometer-agent-notification \
-        ceph \
-        ceph-mds \
         cinder-api \
         cinder-backup \
         cinder-scheduler \
@@ -268,7 +252,6 @@ os_packages=(
 
     ["rpm"]="
         MySQL-python \
-        ceph \
         corosync \
         galera \
         git \
@@ -454,12 +437,42 @@ case "$OS" in
         esac
 
         install_packages_disabled $dir ${monitoring_packages[$(package_type)]}
-        add_epel_repository $DIST
 
+        # Install ICE (Ceph for Enterprise) if possible, otherwise fall back to ceph.com
+        # packages (community edition)
+        if [ -z "$CEPH_USERNAME" ] || [ -z "$CEPH_PASSWORD" ]; then
+            echo "CEPH_USERNAME or CEPH_PASSWORD are not set, we fall back to Ceph Community Edition."
+            add_ceph_rpm_repo
+            install_packages_disabled $dir ceph
+        else
+            ICE_URL=https://$CEPH_USERNAME:$CEPH_PASSWORD@download.inktank.com/enterprise
+            KMOD_REL=3.10-0.1.20140702gitdc9ac62.el7.x86_64
+            wget --no-verbose $ICE_URL/$ICE_RELEASE/ICE-$ICE_RELEASE-rhel7.tar.gz $ICE_URL/$ICE_RELEASE/kmod-libceph-$KMOD_REL.rpm $ICE_URL/$ICE_RELEASE/kmod-rbd-$KMOD_REL.rpm
+            tar xzvf ICE-$ICE_RELEASE-rhel7.tar.gz
+            do_chroot $dir mkdir /tmp/ice_pkg
+            mv kmod*.rpm ceph/*/* $dir/tmp/ice_pkg
+            cat > ${dir}/etc/yum.repos.d/ice.repo <<EOF
+[ice]
+name=Inktank Ceph Enterprise - local packages for Ceph
+baseurl=file:///tmp/ice_pkg
+enabled=1
+gpgcheck=0
+protect=1
+priority=1
+EOF
+            update_system $dir
+            add_epel_repository $DIST
+            install_packages_disabled $dir /tmp/ice_pkg/kmod-rbd-$KMOD_REL.rpm /tmp/ice_pkg/kmod-libceph-$KMOD_REL.rpm ceph
+            rm $dir/etc/yum.repos.d/ice.repo
+        fi
     ;;& # → means "continue"
     "CentOS")
         install_packages $dir $(get_openstack_repository $DIST $dir $OS_VERS)
         install_packages $dir qemu-kvm
+        # Note that ceph is installed before activating EPEL because
+        # we want to use ceph.com packages
+        add_ceph_rpm_repo
+        install_packages_disabled $dir ceph
         add_epel_repository $DIST
         install_packages_disabled $dir ${monitoring_packages[$(package_type)]}
     ;;&

--- a/repositories
+++ b/repositories
@@ -87,3 +87,30 @@ EOF
     ;;
   esac
 }
+
+function add_ceph_rpm_repo() {
+  case "$dist" in
+    $supported_redhat_dists|$supported_centos_dists)
+       cat > ${dir}/etc/yum.repos.d/ceph.repo <<EOF
+[ceph-noarch]
+name=Ceph packages for $basearch
+baseurl=http://ceph.com/rpm/rhel$CODENAME_MAJOR/noarch/
+enabled=1
+gpgcheck=1
+type=rpm-md
+gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+
+[ceph]
+name=Ceph packages for $basearch
+baseurl=http://ceph.com/rpm/rhel$CODENAME_MAJOR/x86_64/
+enabled=1
+gpgcheck=1
+type=rpm-md
+gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+EOF
+    ;;
+    *)
+      fatal_error "OS ($OS) or Release not supported"
+    ;;
+  esac
+}


### PR DESCRIPTION
ICE is Ceph for Enterprise.
- For CentOS7: ensure we use packages from ceph.com repository
  which is the community edition.
- For RHEL7: if CEPH_USERNAME & CEPH_PASSWORD are set, we install ICE
  otherwise we fall back to community edition like CentOS.
