### PR TITLE
openstack-common.install: Fix a deprecated parameter in the puppet configuration

### DIFF
--- a/openstack-common.install
+++ b/openstack-common.install
@@ -92,7 +92,7 @@ os_install_packages () {
 	"Debian" | "Ubuntu")
 	    packages="$softprop puppet augeas-tools iptables build-essential"
 	    install_packages $dir "$packages"
-       	    do_chroot ${dir} sed -e 's/START=yes/START=no/' -i /etc/default/puppet
+	    do_chroot ${dir} sed -e 's/START=yes/START=no/' -i /etc/default/puppet
 	    do_chroot ${dir} sed -e '/templatedir/d' -i /etc/puppet/puppet.conf
 	    ;;
     esac


### PR DESCRIPTION
openstack-common.install: Fix a deprecated parameter in the puppet configuration

Warning: Setting templatedir is deprecated. See http://links.puppetlabs.com/env-settings-deprecations
(at /usr/lib/ruby/vendor_ruby/puppet/settings.rb:1095:in `block in issue_deprecations')
