### PR TITLE
files/disable-tso: Refact script

### DIFF
--- a/files/disable-tso
+++ b/files/disable-tso
@@ -9,30 +9,27 @@
 
 # Authors: Emilien Macchi <emilien.macchi@enovance.com>
 #          Sylvain Afchain <sylvain.afchain@enovance.com>
+#          Dimitri Savineau <dimitri.savineau@enovance.com>
 
 vm_netlink() {
-  IF=`echo $1 | cut -d ':' -f 2`
-  ethtool --offload $IF tso off gso off tx off ufo off gro off
+  ethtool --offload $1 tso off gso off tx off ufo off gro off
 }
 
 router_netlink() {
-  IF=`echo $1 | cut -d ':' -f 2`
-  ethtool --offload $IF tso off gso off tx off ufo off gro off
   ip netns | grep qrouter | while read NS; do
-    ip netns exec $NS ethtool --offload $IF tso off gso off tx off ufo off gro off
+    ip netns exec $NS ethtool --offload $1 tso off gso off tx off ufo off gro off
   done
 }
 
 ip_monitor() {
   ip monitor link | while read LINE; do
-    case $LINE in
-      Deleted*)
-        ;;
+    IF=$(echo $LINE | egrep "^[0-9]" | cut -d ':' -f 2)
+    case $IF in
       *qvo*|*qvb*|*qbr*)
-        vm_netlink $LINE
+        vm_netlink $IF
         ;;
        *qr*)
-        router_netlink $LINE
+        router_netlink $IF
         ;;
     esac
   done


### PR DESCRIPTION
Previous commit c98f8f55f745dc4d940a2c60fbe773d36fa57262 was not enough to fix the problem.

The $LINE variable passed to vm_netlink and router_netlink doesn't use double quotes so each column in $LINE is an argument and not a unique string.

```
7: qr-138be9c2-45: <BROADCAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN
$1       $2                $3               $4  $5   $6     $7     $8     $9
```

Instead of getting the interface name in each function, the interface name is filtered in ip_monitor and ethtool isn't applied to some interface like tap\* matching in the regex.

```
54: tap1c38b3fb-f7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master qbr1c38b3fb-f7 state UNKNOWN mode DEFAULT qlen 500
```

ethool was applied to tap1c38b3fb-f7 because the regex matches with qbr1c38b3fb-f7

Signed-off-by: Dimitri Savineau dimitri.savineau@enovance.com
