### PR TITLE
Allow root part and FS to be resized on Centos

### DIFF
--- a/cloud.install
+++ b/cloud.install
@@ -71,7 +71,7 @@ EOF
 	    ;;
 	"CentOS")
 	    add_epel_repository $DIST
-	    install_packages $dir "cloud-init"
+	    install_packages $dir "cloud-init cloud-utils cloud-utils-growpart"
 	    remove_epel_repository $DIST
 	    ;;
 	*)
@@ -86,6 +86,7 @@ preserve_hostname: False
 
 cloud_init_modules:
  - bootcmd
+ - growpart
  - resizefs
  - set_hostname
  - update_hostname


### PR DESCRIPTION
The resize does not work on Centos but after those change it works. So please merge it.
- Add growpart package
- Add growpart module in cloud.cfg
