### PR TITLE
add rabbitmq signing-key-public

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -148,6 +148,8 @@ type=rpm-md
 gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
 EOF
         fi
+
+        add_rabbitmq_repo
         ;;
     *)
         fatal_error "OS ($OS) or Release not supported"

--- a/repositories
+++ b/repositories
@@ -123,6 +123,7 @@ deb ${RABBITMQ_URL:=http://www.rabbitmq.com/}debian/ testing main
 EOF
     ;;
     "CentOS"|"RedHatEnterpriseServer")
+    do_chroot $dir rpm --import ${RABBITMQ_URL:=http://www.rabbitmq.com/}rabbitmq-signing-key-public.asc
     ;;
     *)
       fatal_error "OS ($OS) or Release not supported"


### PR DESCRIPTION
The rabbitmq puppet module will try to download rabbitmq key
during the install process. But if there is no external acces it
will fail. Install the key during the image build will fix this issue
