### PR TITLE
openstack-full.install: add kernel debug package for Debian and RHEL

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -315,6 +315,7 @@ prod_packages=(
         file \
         iotop \
         less \
+        linux-image-$(uname -r)-dbg \
         ltrace \
         manpages \
         manpages-dev \
@@ -333,6 +334,7 @@ prod_packages=(
         bash-completion \
         crash \
         iotop \
+        kernel-debuginfo \
         ltrace \
         mtr \
         nmap \


### PR DESCRIPTION
Add the kernel debug package to be able to read a crash dump
Kernel debug can be used later with systemtap if we want to use it.
