### PR TITLE
install-server: Adding PXE & Health bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ $(INST)/chef-server.done: chef-server.install $(INST)/base.done
 	./chef-server.install $(INST)/base $(INST)/chef-server $(VERS)
 	touch $(INST)/chef-server.done
 
-install-server: $(INST)/install-server.done
+install-server: $(INST)/pxe.done $(INST)/health.done $(INST)/install-server.done
 $(INST)/install-server.done: install-server.install $(INST)/openstack-common.done puppet-master.install
 	./install-server.install $(INST)/openstack-common $(INST)/install-server $(VERS)
 	touch $(INST)/install-server.done
@@ -132,6 +132,18 @@ $(INST)/base.done: $(ARCHIVE)/$(BVERS)/base-$(BVERS).edeploy
 	mkdir -p $(INST)/base
 	tar zxf $(ARCHIVE)/$(BVERS)/base-$(BVERS).edeploy -C $(INST)/base
 	touch $(INST)/base.done
+
+$(INST)/pxe.done: $(ARCHIVE)/$(BVERS)/initrd.pxe
+	rm -rf $(INST)/initrd.pxe
+	cp $(ARCHIVE)/$(BVERS)/initrd.pxe $(INST)/initrd.pxe
+	cp $(ARCHIVE)/$(BVERS)/base/boot/vmlinuz-* $(INST)/vmlinuz
+	touch $(INST)/pxe.done
+
+$(INST)/health.done: $(ARCHIVE)/$(BVERS)/health.pxe
+	rm -rf $(INST)/health.pxe
+	cp $(ARCHIVE)/$(BVERS)/health.pxe $(INST)/health.pxe
+	touch $(INST)/health.done
+
 
 dist:
 	tar zcvf ../edeploy-roles.tgz Makefile README.rst *.install *.exclude

--- a/install-server.install
+++ b/install-server.install
@@ -42,6 +42,8 @@ update_repositories $dir
 $ORIG/deploy.install $dir $dir $version
 install_packages_disabled $dir dnsmasq
 
+mkdir -p $dir/var/lib/tftpboot/
+cp $INST/vmlinuz $INST/initrd.pxe $INST/health.pxe $dir/var/lib/tftpboot/
 
 #################
 # Puppet master #


### PR DESCRIPTION
The install-server have to provide a pxe and health bootstrap to insure deploiement
of nodes.

Please note that starting from this commit, install-server requires pxe & health-check target to be pre-built in addition of the actual base one.
