### PR TITLE
installserver: Differentiate puppetdb from puppetmaster

### DIFF
--- a/install-server.install
+++ b/install-server.install
@@ -51,6 +51,12 @@ cp $INST/vmlinuz $INST/initrd.pxe $INST/health.pxe $dir/var/lib/tftpboot/
 
 $SRC/puppet-master.install $dir $dir $version
 
+###################
+# PuppetDB server #
+###################
+
+$SRC/puppetdb-server.install $dir $dir $version
+
 ##############
 # Serverspec #
 ##############

--- a/puppet-master.install
+++ b/puppet-master.install
@@ -35,7 +35,7 @@ rh_install_passenger () {
     do_chroot ${dir} yum -y localinstall /tmp/ruby-devel-2.0.0.353-20.el7.x86_64.rpm
 
     # Install all dependencies to run Puppet in passenger mode
-    install_packages_disabled $dir puppet-server git augeas ntp httpd puppetdb puppetdb-terminus python-pip mod_wsgi apr-util-devel apr-devel httpd-devel zlib-devel openssl-devel libcurl-devel gcc-c++ gcc mod_ssl
+    install_packages_disabled $dir puppet-server git augeas ntp httpd puppetdb-terminus python-pip mod_wsgi apr-util-devel apr-devel httpd-devel zlib-devel openssl-devel libcurl-devel gcc-c++ gcc mod_ssl
 
     # passenger is not packaged in el7, let's install & configure it
     do_chroot ${dir} gem install rack passenger
@@ -115,7 +115,7 @@ EOF
 	    do_chroot ${dir} dpkg -i puppetlabs-release-$RELEASE.deb
 	    do_chroot ${dir} rm puppetlabs-release-$RELEASE.deb
 	    do_chroot ${dir} apt-get update
-	    PACKAGES="puppetmaster puppetmaster-passenger puppet augeas-tools git ntp puppetdb puppetdb-terminus"
+	    PACKAGES="puppetmaster puppetmaster-passenger puppet augeas-tools git ntp puppetdb-terminus"
 	    install_packages_disabled $dir $PACKAGES
 	    do_chroot ${dir} a2dissite puppetmaster
             hiera_dir=usr/lib/ruby/vendor_ruby/hiera


### PR DESCRIPTION
Now that puppetdb has its own role, we integrate it to install-server,
and remove it from puppetmaster.

Depends on: https://github.com/enovance/edeploy/pull/150
