### PR TITLE
openstack-full.install: Remove duplicate backports

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -71,11 +71,6 @@ EOF
      cat > ${dir}/etc/apt/sources.list.d/ceph.list <<EOF
 deb http://eu.ceph.com/debian-firefly $DIST main
 EOF
-     do_chroot $dir apt-key adv --keyserver keyserver.ubuntu.com --recv 049ED9B94765572E
-     cat > ${dir}/etc/apt/sources.list.d/qemu-backports.list <<EOF
-deb http://ftp.de.debian.org/debian wheezy-backports main
-EOF
-     do_chroot $dir apt-key adv --keyserver keyserver.ubuntu.com --recv 049ED9B94765572E
      cat > ${dir}/etc/apt/sources.list.d/haproxy-wheezy.list <<EOF
 deb http://41.apt-proxy.gplhost.com/debian haproxy-wheezy main
 EOF


### PR DESCRIPTION
openstack-full > openstack-common > cloud

We already have backports declared in cloud.install

https://github.com/enovance/edeploy-roles/blob/master/cloud.install#L39-L41

Signed-off-by: Dimitri Savineau dimitri.savineau@enovance.com
