### PR TITLE
repositories: Fix percona pinning on debian

### DIFF
--- a/repositories
+++ b/repositories
@@ -198,7 +198,7 @@ EOF
 Explanation: : percona-pin
 Package: *
 Pin: origin "repo.percona.com"
-Pin-Priority: 100
+Pin-Priority: 600
 EOF
             update_repositories $dir
             ;;


### PR DESCRIPTION
percona-toolkit package is also present in debian repository. Have a pinning
at 100 for percona repository is not enough to get latest release.
We need to have a pinning value > 500 (default debian repository).

Signed-off-by: Dimitri Savineau dimitri.savineau@enovance.com
