### PR TITLE
openstack-full: Use Debian meta-packages for linux-{headers,image}

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -359,7 +359,7 @@ case "$OS" in
     "Debian")
         add_percona_deb_repo
         update_repositories $dir
-        install_packages_disabled $dir -t wheezy-backports linux-headers-3.16-0.bpo.3-amd64 linux-image-3.16-0.bpo.3-amd64
+        install_packages_disabled $dir -t wheezy-backports linux-headers-amd64 linux-image-amd64
         install_packages_disabled $dir ${backup_packages[$(package_type)]}
         install_packages_disabled $dir ${prod_packages[$(package_type)]}
     ;&


### PR DESCRIPTION
Debian build is broken due to an NMU on Linux kernel,headers; This
commit update packages names, using meta-packages in order to avoid
potential future issues.
- linux-headers-3.16-0.bpo.3-amd64 →  linux-headers-3.16.0-0.bpo.4-amd64
- linux-image-3.16-0.bpo.3-amd64 → linux-image-3.16.0-0.bpo.4-amd64

Note: This fixes the build issue on Debian.

 :bangbang: **Question** We pin-point the Kernel version in order to avoid unattended updates?
