### PR TITLE
tempest/debian: install dependencies for icehouse

### DIFF
--- a/tempest.install
+++ b/tempest.install
@@ -42,6 +42,9 @@ case "$(package_tool)" in
         install_packages $dir "$PACKAGES python-openssl libxml2-dev libxslt-dev libpq-dev python-dev python-virtualenv libffi-dev python-junitxml"
         mkdir -p ${dir}/usr/share/openstack-tempest-icehouse
         git clone 'https://github.com/openstack/tempest' ${dir}/usr/share/openstack-tempest-icehouse
+        # lib that are not packaged in Debian
+        do_chroot ${dir} bash -c 'pip install --no-deps tempest-lib'
+        do_chroot ${dir} bash -c "pip install --no-deps oslo.serialization oslo.utils --install-option='--prefix=/usr' --install-option='--install-lib=/usr/lib/python2.7/dist-packages/'"
         do_chroot ${dir} bash -c 'cd /usr/share/openstack-tempest-icehouse; python ./setup.py install --single-version-externally-managed --root /'
 
         ;;


### PR DESCRIPTION
Since we install Tempest from source, we need some dependencies to make
it work.
