### PR TITLE
repositories: Temporary fix treasuredata.com repo

### DIFF
--- a/repositories
+++ b/repositories
@@ -44,7 +44,9 @@ add_fluentd_repo() {
     "Debian")
       do_chroot ${dir} wget -O- http://packages.treasure-data.com/debian/RPM-GPG-KEY-td-agent | do_chroot ${dir} apt-key add -
       cat > ${dir}/etc/apt/sources.list.d/treasure-data.list<<EOF
-deb http://packages.treasuredata.com/2/debian/wheezy/ wheezy contrib
+#deb http://packages.treasuredata.com/2/debian/wheezy/ wheezy contrib
+#FIXME(sbadia): Since 2014/12/22 Release{,.gpg} doesn't match to Packages{,.gz}, I've send an email to treasuredata team
+deb http://os-ci-admin.ring.enovance.com/mirror/treasuredata/2/debian/wheezy/ wheezy contrib
 EOF
     ;;
     "CentOS"|"RedHatEnterpriseServer")


### PR DESCRIPTION
treasuredata.com is now cached by apt-miror on os-ci-admin.
Since 2014/12/22 Release{,.gpg} doesn't match to Packages{,.gz}
I've send an email to treasuredata team.

This patch fix the issue, I revert this patch when upstream repo
was fixed.
