### PR TITLE
Purge old pre-masterless PuppetDB configuration

### DIFF
--- a/upgrade/I.1.3.0/J.1.0.0/roles/install-server/tasks/main.yml
+++ b/upgrade/I.1.3.0/J.1.0.0/roles/install-server/tasks/main.yml
@@ -6,10 +6,25 @@
   with_items:
     - "{{ webserver }}"
     - puppetdb
+    - postgresql
   tags: install_server
 
 - name: edeploy upgrade
   edeploy: command=upgrade version={{ distro }}-{{ version }}
+  tags: install_server
+
+- name: Ensure old puppetdb configuration file are removed (puppetdb.conf and routes.yaml)
+  file: path=/etc/puppet/{{ item }} state=absent
+  with_items:
+    - puppetdb.conf
+    - routes.yaml
+  tags: install_server
+
+- name: Ensure old puppetdb configurations are removed from puppet.conf
+  lineinfile: dest=/etc/puppet/puppet.conf state=absent regexp="\s*{{ item }}"
+  with_items:
+    - storeconfigs
+    - reports
   tags: install_server
 
 # We don't restart PuppetDB now, because it's managed by Puppet


### PR DESCRIPTION
In I-1.3.0, the Puppet setup was an agent/server setup.
Hence PuppetDB was configured in the [agent] section of puppet.conf.
Since starting from J-1.0.0 the setup will be masterless, we need to
purge this configuration, so the installer can, by itself, reconfigure
the proper puppetdb configuration settings.