### PR TITLE
[DO NOT MERGE UNTIL J-1.1.0] elasticsearch: Bump to version 1.4.x

### DIFF
--- a/repositories
+++ b/repositories
@@ -11,9 +11,9 @@ EOF
     "CentOS"|"RedHatEnterpriseServer")
       do_chroot ${dir} rpm --import http://packages.elasticsearch.org/GPG-KEY-elasticsearch
       cat > ${dir}/etc/yum.repos.d/elasticsearch.repo <<EOF
-[elasticsearch-1.0]
-name=Elasticsearch repository for 1.0.x packages
-baseurl=http://packages.elasticsearch.org/elasticsearch/1.0/centos
+[elasticsearch-1.4]
+name=Elasticsearch repository for 1.4.x packages
+baseurl=http://packages.elasticsearch.org/elasticsearch/1.4/centos
 gpgcheck=1
 gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
 enabled=1


### PR DESCRIPTION
Kibana 4 needs elasticsearch 1.4.4 as a minimal requirement.
Hence we bump our elasticsearch version from 1.0.x to 1.4.x.