### PR TITLE
openstack-full: Fix galera package name (needed by mariadb-galera-server-5.5)

### DIFF
--- a/openstack-full.install
+++ b/openstack-full.install
@@ -168,7 +168,7 @@ os_packages=(
         cinder-scheduler \
         cinder-volume \
         euca2ools \
-        galera \
+        galera-3 \
         git \
         glance \
         haproxy \


### PR DESCRIPTION
A recent update of mariadb-galera-server-5.5 (5.5.42+maria-1~wheezy)
introduce a new strong dependency to galera-3 (>= 25.3, shipped by
nwps.ws, 25.3.9-wheezy). For the moment we used the galera package from
Debian official repositories (galera 25.3.5-wheezy).

This patch update openstack-full role to match this recent update (10-Mar-2015 07:21)