### PR TITLE
monitor: Install redis package from testing repo.

### DIFF
--- a/monitor-server.install
+++ b/monitor-server.install
@@ -28,7 +28,7 @@ ORIG=$(cd $(dirname $0); pwd)
 declare -A packages
 packages=(
     ["deb"]="rabbitmq-server"
-    ["rpm"]="redis rabbitmq-server"
+    ["rpm"]="rabbitmq-server"
 )
 
 install_ib_if_needed $ORIG $dir
@@ -62,6 +62,8 @@ case "$OS" in
               install_packages $dir sensu uchiwa
             ;;
             7)
+              # TODO (spredzy) : https://bugzilla.redhat.com/show_bug.cgi?id=1191528
+              do_chroot ${dir} yum -y install --enablerepo=epel-testing redis-2.8.19-1.el7
               cp $SRC/files/sensu-0.13.1-1.x86_64.rpm ${dir}/tmp/
               do_chroot ${dir} yum -y localinstall /tmp/sensu-0.13.1-1.x86_64.rpm
               cp $SRC/files/uchiwa-0.2.1-1.x86_64.rpm ${dir}/tmp/

--- a/openstack-full.install
+++ b/openstack-full.install
@@ -311,7 +311,6 @@ os_packages=(
         python-psutil \
         python-swiftclient \
         rabbitmq-server \
-        redis \
         rubygem-json \
         rubygems \
         sysfsutils \


### PR DESCRIPTION
The current redis package is broken[1]. A fix has been pushed to
testing. Hence we rely on this package

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1191528