### PR TITLE
improve RH7.0.-I.1.2.1 → RH7.0-I.1.30 upgrade

### DIFF
--- a/upgrade/I.1.2.0/I.1.3.0/roles/compute/tasks/main.yml
+++ b/upgrade/I.1.2.0/I.1.3.0/roles/compute/tasks/main.yml
@@ -24,7 +24,7 @@
   when: ansible_distribution == 'RedHat'
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable --service nova-compute --host {{ ansible_fqdn }}
+  command: nova-manage service enable --service nova-compute --host {{ ansible_hostname }}
   tags: before_config
   when: ansible_distribution == 'Debian'
 

--- a/upgrade/I.1.2.0/I.1.3.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.2.0/I.1.3.0/roles/openstack-full/tasks/main.yml
@@ -29,6 +29,11 @@
   edeploy: command=upgrade version={{ distro }}-{{ version }}
   tags: before_config
 
+- name: reload systemd scripts list
+  command: systemctl daemon-reload
+  tags: before_config
+  when: ansible_distribution == 'RedHat'
+
 - name: start rabbitmq
   service: name=rabbitmq-server state=started
   tags: before_config
@@ -40,11 +45,6 @@
 # For other nodes, they will be started by Puppet later.
 - name: create systemd mysql-bootstrap script
   copy: src=mysql-bootstrap.service dest=/usr/lib/systemd/system/mysql-bootstrap.service
-  tags: before_config
-  when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
-
-- name: reload systemd scripts list
-  command: systemctl daemon-reload
   tags: before_config
   when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
 

--- a/upgrade/I.1.2.0/I.1.3.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.2.0/I.1.3.0/roles/openstack-full/tasks/main.yml
@@ -65,7 +65,7 @@
   when: ansible_distribution == 'RedHat'
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable --service nova-compute --host {{ ansible_fqdn }}
+  command: nova-manage service enable --service nova-compute --host {{ ansible_hostname }}
   tags: before_config
   when: ansible_distribution == 'Debian'
 

--- a/upgrade/I.1.2.1/I.1.3.0/roles/compute/tasks/main.yml
+++ b/upgrade/I.1.2.1/I.1.3.0/roles/compute/tasks/main.yml
@@ -24,7 +24,7 @@
   when: ansible_distribution == 'RedHat'
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable --service nova-compute --host {{ ansible_fqdn }}
+  command: nova-manage service enable --service nova-compute --host {{ ansible_hostname }}
   tags: before_config
   when: ansible_distribution == 'Debian'
 

--- a/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # file: roles/openstack-full/tasks/main.yml
 
+# NOTE(Gonéri): rabbitmq version has been changed on RedHat. It's not possible
+# to mix the old version and new version in the same cluster. To do so, we need
+# to upgrade all the nodes at the same time. That's why this roles have to be
+# run serial==0.
+
 # Debian has a kernel upgrade from 3.14 to 3.16
 # So we need to restart the compute nodes and migrate the instances before.
 - name: migrate instances
@@ -29,29 +34,50 @@
   edeploy: command=upgrade version={{ distro }}-{{ version }}
   tags: before_config
 
+- name: create systemd mysql-bootstrap script
+  copy: src=mysql-bootstrap.service dest=/etc/systemd/system/mysqld.service
+  tags: before_config
+  when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
+
 - name: reload systemd scripts list
   command: systemctl daemon-reload
   tags: before_config
   when: ansible_distribution == 'RedHat'
 
-- name: start rabbitmq
+- name: bootstrap mysql cluster again
+  service: name=mysqld state=started
+  tags: before_config
+  when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
+
+- name: restart the mysql nodes
+  service: name=mysqld state=started
+  tags: before_config
+  when: ansible_distribution == 'RedHat'
+
+- name: drop the mysql-bootstrap script
+  file: path=/etc/systemd/system/mysqld.service state=absent
+  tags: before_config
+  when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
+
+# RabbitMQ
+- name: start RabbitMQ nodes
   service: name=rabbitmq-server state=started
   tags: before_config
-  when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
+  when: ansible_distribution == 'RedHat'
+  register: rabbitmq_result
+  ignore_errors: yes
 
-# Red Hat upgrade Galera to 25.3.5-5.el7ost
-# since we start in serial mode one by one, we are sure here that the first node
-# in the list will be master.
-# For other nodes, they will be started by Puppet later.
-- name: create systemd mysql-bootstrap script
-  copy: src=mysql-bootstrap.service dest=/usr/lib/systemd/system/mysql-bootstrap.service
+- name: start RabbitMQ nodes
+  service: name=rabbitmq-server state=started
   tags: before_config
-  when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
+  when: ansible_distribution == 'RedHat' and rabbitmq_result|failed
+  register: rabbitmq_result
+  ignore_errors: yes
 
-- name: bootstrap mysql cluster again
-  service: name=mysql-bootstrap state=restarted
+- name: start RabbitMQ nodes
+  service: name=rabbitmq-server state=started
   tags: before_config
-  when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
+  when: ansible_distribution == 'RedHat' and rabbitmq_result|failed
 
 # libvirtd is updated on RHEL7
 - name: restart libvirtd after upgrade

--- a/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
@@ -29,6 +29,11 @@
   edeploy: command=upgrade version={{ distro }}-{{ version }}
   tags: before_config
 
+- name: reload systemd scripts list
+  command: systemctl daemon-reload
+  tags: before_config
+  when: ansible_distribution == 'RedHat'
+
 - name: start rabbitmq
   service: name=rabbitmq-server state=started
   tags: before_config
@@ -40,11 +45,6 @@
 # For other nodes, they will be started by Puppet later.
 - name: create systemd mysql-bootstrap script
   copy: src=mysql-bootstrap.service dest=/usr/lib/systemd/system/mysql-bootstrap.service
-  tags: before_config
-  when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
-
-- name: reload systemd scripts list
-  command: systemctl daemon-reload
   tags: before_config
   when: ansible_distribution == 'RedHat' and inventory_hostname == groups['openstack-full'][-1]
 

--- a/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
@@ -30,6 +30,13 @@
   ignore_errors: yes
   when: ansible_distribution == 'RedHat'
 
+# NOTE(Gonéri): to avoid split-brain we ensure there is no mysqld daemon running
+- name: kill reamining mysqld daemon
+  command: pkill -9 mysqld
+  ignore_errors: yes
+  tags: before_config
+  when: ansible_distribution == 'RedHat'
+
 - name: edeploy upgrade
   edeploy: command=upgrade version={{ distro }}-{{ version }}
   tags: before_config

--- a/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
@@ -65,7 +65,7 @@
   when: ansible_distribution == 'RedHat'
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable --service nova-compute --host {{ ansible_fqdn }}
+  command: nova-manage service enable --service nova-compute --host {{ ansible_hostname }}
   tags: before_config
   when: ansible_distribution == 'Debian'
 

--- a/upgrade/I.1.3.0/J.1.0.0/roles/compute/tasks/main.yml
+++ b/upgrade/I.1.3.0/J.1.0.0/roles/compute/tasks/main.yml
@@ -20,7 +20,7 @@
 # Mark the nova-compute service as disabled to prevent Nova from scheduling
 # any new servers on this node
 - name: disable nova-compute to prevent instance scheduling
-  command: nova-manage service disable {{ ansible_fqdn }} nova-compute
+  command: nova-manage service disable --host {{ ansible_hostname }} --service nova-compute
   tags: before_config
 
 - name: stop openstack services

--- a/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
@@ -145,10 +145,9 @@
   tags: before_config
   when: inventory_hostname == groups['openstack-full'][-1]
 
-- name: bootstrap mysql cluster again
-  service: name=mysql-bootstrap state=restarted
+- name: restart mysql cluster again
+  service: name=mysqld state=restarted
   tags: before_config
-  when: inventory_hostname == groups['openstack-full'][-1]
 
 - name: restart HAproxy service
   service: name=haproxy state=restarted

--- a/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
@@ -15,7 +15,7 @@
 # Mark the nova-compute service as disabled to prevent Nova from scheduling
 # any new servers on this node
 - name: disable nova-compute to prevent instance scheduling
-  command: nova-manage service disable {{ ansible_fqdn }} nova-compute
+  command: nova-manage service disable {{ ansible_hostname }} nova-compute
   tags: before_config
 
 - name: stop keepalived
@@ -299,7 +299,7 @@
   tags: before_config
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable {{ ansible_fqdn }} nova-compute
+  command: nova-manage service enable --host {{ ansible_hostname }} --service nova-compute
   tags: before_config
 
 - name: Ensure old puppet ssl files are removed


### PR DESCRIPTION
Some fixes for the RH7.0.-I.1.2.1 → RH7.0-I.1.30 upgrade path.

During this upgrade, the version of Galera and RabbitMQ are changed. Because of that,
the two clusters have to be completely restarted.

Instead of doing the upgrade of openstack-full node per node, we upgrade all the
nodes at the same time to be able to upgrade and restart the galera and rabbitmq
cluster as soon as possible.
This way we avoid the following cases:
  - some MySQL may fail to stop and still be using the old MySQL version while the other are
    already in the new cluster. We now `kill -9` all remaining mysqld process now and restart the
    full cluster at the same time to spot error as soon as possible.
  - RabbitMQ cluster failed to start at the first try after the upgrade but nothing catch the
    issue. The error is silently ignored until we reach step4 of the upgrade process.

With this change the `serial` key of `top/etc/ansible/site.yml.tmpl` has to be switched from `1` to `0`.