### PR TITLE
I.1.3.0 → J.1.0.0: avoid conflict with mysqlchk

### DIFF
--- a/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
@@ -22,10 +22,6 @@
   service: name=keepalived state=stopped
   tags: before_config
 
-- name: stop HAproxy service
-  service: name=haproxy state=stopped
-  tags: before_config
-
 - name: stop openstack services
   service: name={{ item }} state=stopped
   with_items:
@@ -115,21 +111,6 @@
   tags: before_config
   when: ansible_distribution == 'Debian'
 
-- name: change mysqlchk port from 9200 to 8200
-  replace:
-    dest={{ item }}
-    regexp='9200'
-    replace='8200'
-  with_items:
-    - "/etc/services"
-    - "/etc/xinetd.d/mysqlchk"
-    - "/etc/haproxy/haproxy.cfg"
-  tags: before_config
-
-- name: restart xinetd
-  service: name=xinetd state=restarted
-  tags: before_config
-
 - name: start openvswitch service
   service: name=openvswitch-switch state=started
   tags: before_config
@@ -149,10 +130,6 @@
   service: name=mysql-bootstrap state=restarted
   tags: before_config
   when: inventory_hostname == groups['openstack-full'][-1]
-
-- name: restart HAproxy service
-  service: name=haproxy state=restarted
-  tags: before_config
 
 # we start keepalived on the last openstack-full node, to ensure all nodes
 # have xinetd updated, otherwise the VIP can come back on the first node
@@ -361,3 +338,22 @@
     - "{{ glance_registry }}"
   tags: after_config
   ignore_errors: yes
+
+- name: change mysqlchk port from 9200 to 8200
+  replace:
+    dest={{ item }}
+    regexp='9200'
+    replace='8200'
+  with_items:
+    - "/etc/services"
+    - "/etc/xinetd.d/mysqlchk"
+    - "/etc/haproxy/haproxy.cfg"
+  tags: before_config
+
+- name: restart xinetd
+  service: name=xinetd state=restarted
+  tags: before_config
+
+- name: restart HAproxy service
+  service: name=haproxy state=restarted
+  tags: before_config


### PR DESCRIPTION
To access MySQL, DB migration scripts use the VIP. If the VIP is on the
first node, the services statues will rely on the node1 haproxy.

The status before the DB migrations is:
- first node is out of the MySQL cluster because the mysqld is stopped
- the other nodes are in the cluster and mysqlchk is on port 9200

If we ask haproxy to check the MySQL servers on port 8200, we will get
all the running nodes out of the cluster, and the migration will
fail.

With this commit, we postpone the mysqlchk port reconfiguration to get
the DB migration.
