### PR TITLE
J.1.0 kill mysqld

### DIFF
--- a/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
@@ -91,6 +91,11 @@
   tags: before_config
   ignore_errors: yes
 
+- name: kill reamining mysqld daemon
+  command: pkill -9 mysqld
+  ignore_errors: yes
+  tags: before_config
+
 - name: stop Ceph services
   service: name=ceph state=stopped
   tags: before_config


### PR DESCRIPTION
 I.1.3.0 → J.1.0.0: ensure mysqld is really killed

If we failed to stop mysqld, it will remain in an unstable state
while a new cluster will be bootstrapped.
Since we ignore the “stop mysql” errors, we just do a `pkill -9 mysqld`
later to be sure there is no remaining mysqld process.