### PR TITLE
install-server: Add python pandas for cardiff

### DIFF
--- a/install-server.install
+++ b/install-server.install
@@ -232,4 +232,10 @@ case "$OS" in
         ;;
 esac
 
+###########
+# Cardiff #
+###########
+
+do_chroot $dir pip install pandas
+
 # install-server.install ends here


### PR DESCRIPTION
Cardiff depends on python pandas module which is not installed.
This patch installs this module with pip on install-server role.
```
$ ./cardiff.py 
Traceback (most recent call last):
  File "./cardiff.py", line 25, in <module>
    import check
  File "/home/ds/Documents/repo/github/edeploy/tools/cardiff/check.py", line 5, in <module>
    from pandas import *
ImportError: No module named pandas
```