### PR TITLE
build: prepare J.1.2.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ TOP=/var/lib/debootstrap
 ARCHIVE=$(TOP)/install
 DVER=D7
 PVER=J
-REL=1.1.0
+REL=1.2.0
 VERSION:=$(PVER).$(REL)
 VERS=$(DVER)-$(VERSION)
 DIST=wheezy
-BREL=1.9.0
+BREL=1.10.0
 BVERS=$(DVER)-$(BREL)
 
 ARCH=amd64


### PR DESCRIPTION
Prepare next release that will be J.1.2.0 based on eDeploy 1.10.0.