### PR TITLE
install-server: Add python pandas for cardiff

### DIFF
--- a/install-server.install
+++ b/install-server.install
@@ -213,4 +213,10 @@ $SRC/monitor-server.install $dir $dir $version
 
 $SRC/tempest.install $dir $dir $version
 
+###########
+# Cardiff #
+###########
+
+do_chroot $dir pip install pandas
+
 # install-server.install ends here


### PR DESCRIPTION
Cardiff depends on python pandas module which is not installed.
This patch installs this module with pip on install-server role.

Signed-off-by: Dimitri Savineau <dimitri.savineau@enovance.com>
(cherry picked from commit f5484c1f9e36f32731b8385394f92badfe94c175)

Conflicts:
	install-server.install