### PR TITLE
Extra packages for install-server

### DIFF
--- a/install-server.install
+++ b/install-server.install
@@ -126,6 +126,7 @@ openstack_packages=(
 "
 
     ["rpm"]="
+        nfs-utils \
         python-cinderclient \
         python-heatclient \
         python-keystoneclient \

--- a/install-server.install
+++ b/install-server.install
@@ -138,6 +138,7 @@ openstack_packages=(
         python-swiftclient \
         openstack-nova-common \
         sos \
+        vim-enhanced \
 ")
 
 case "$OS" in


### PR DESCRIPTION
vim: This is installed on all debian images already, as well as the openstack-full images.  The lack of consistency is annoying for vim users (or this one at least)

nfs-utils: Makes it possible to store the large edeploy images on shared NFS storage. ( combines nicely with https://github.com/enovance/config-tools/pull/26 )