### PR TITLE
nova-manage expects the hostname, not the FQDN

### DIFF
--- a/upgrade/I.1.2.0/I.1.3.0/roles/compute/tasks/main.yml
+++ b/upgrade/I.1.2.0/I.1.3.0/roles/compute/tasks/main.yml
@@ -24,7 +24,7 @@
   when: ansible_distribution == 'RedHat'
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable --service nova-compute --host {{ ansible_fqdn }}
+  command: nova-manage service enable --service nova-compute --host {{ ansible_hostname }}
   tags: before_config
   when: ansible_distribution == 'Debian'
 

--- a/upgrade/I.1.2.0/I.1.3.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.2.0/I.1.3.0/roles/openstack-full/tasks/main.yml
@@ -65,7 +65,7 @@
   when: ansible_distribution == 'RedHat'
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable --service nova-compute --host {{ ansible_fqdn }}
+  command: nova-manage service enable --service nova-compute --host {{ ansible_hostname }}
   tags: before_config
   when: ansible_distribution == 'Debian'
 

--- a/upgrade/I.1.2.1/I.1.3.0/roles/compute/tasks/main.yml
+++ b/upgrade/I.1.2.1/I.1.3.0/roles/compute/tasks/main.yml
@@ -24,7 +24,7 @@
   when: ansible_distribution == 'RedHat'
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable --service nova-compute --host {{ ansible_fqdn }}
+  command: nova-manage service enable --service nova-compute --host {{ ansible_hostname }}
   tags: before_config
   when: ansible_distribution == 'Debian'
 

--- a/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.2.1/I.1.3.0/roles/openstack-full/tasks/main.yml
@@ -65,7 +65,7 @@
   when: ansible_distribution == 'RedHat'
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable --service nova-compute --host {{ ansible_fqdn }}
+  command: nova-manage service enable --service nova-compute --host {{ ansible_hostname }}
   tags: before_config
   when: ansible_distribution == 'Debian'
 

--- a/upgrade/I.1.3.0/J.1.0.0/roles/compute/tasks/main.yml
+++ b/upgrade/I.1.3.0/J.1.0.0/roles/compute/tasks/main.yml
@@ -20,7 +20,7 @@
 # Mark the nova-compute service as disabled to prevent Nova from scheduling
 # any new servers on this node
 - name: disable nova-compute to prevent instance scheduling
-  command: nova-manage service disable {{ ansible_fqdn }} nova-compute
+  command: nova-manage service disable --host {{ ansible_hostname }} --service nova-compute
   tags: before_config
 
 - name: stop openstack services

--- a/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
+++ b/upgrade/I.1.3.0/J.1.0.0/roles/openstack-full/tasks/main.yml
@@ -15,7 +15,7 @@
 # Mark the nova-compute service as disabled to prevent Nova from scheduling
 # any new servers on this node
 - name: disable nova-compute to prevent instance scheduling
-  command: nova-manage service disable {{ ansible_fqdn }} nova-compute
+  command: nova-manage service disable {{ ansible_hostname }} nova-compute
   tags: before_config
 
 - name: stop keepalived
@@ -299,7 +299,7 @@
   tags: before_config
 
 - name: allow instance scheduling on the compute node
-  command: nova-manage service enable {{ ansible_fqdn }} nova-compute
+  command: nova-manage service enable --host {{ ansible_hostname }} --service nova-compute
   tags: before_config
 
 - name: Ensure old puppet ssl files are removed


### PR DESCRIPTION
As discussed with Emilien Macchi and Dimitri Savineau. The
`nova-manage` `--hostname` parameter expects a hostname, not
a FQDN. For an unknown reason, `nova-manage service list` returns
the full FQDN on our internal CI. This is not the case on the other
installations.

(cherry picked from commit 39bcc8be6b3c076546da7cc9c84c01853f10f02f)