### PR TITLE
Rollback 30f0ec5f - Treasuredata repo is now running fine

### DIFF
--- a/repositories
+++ b/repositories
@@ -44,9 +44,7 @@ add_fluentd_repo() {
     "Debian")
       do_chroot ${dir} wget -O- http://packages.treasure-data.com/debian/RPM-GPG-KEY-td-agent | do_chroot ${dir} apt-key add -
       cat > ${dir}/etc/apt/sources.list.d/treasure-data.list<<EOF
-#deb http://packages.treasuredata.com/2/debian/wheezy/ wheezy contrib
-#FIXME(sbadia): Since 2014/12/22 Release{,.gpg} doesn't match to Packages{,.gz}, I've send an email to treasuredata team
-deb http://os-ci-admin.ring.enovance.com/mirror/treasuredata/2/debian/wheezy/ wheezy contrib
+deb http://packages.treasuredata.com/2/debian/wheezy/ wheezy contrib
 EOF
     ;;
     "CentOS"|"RedHatEnterpriseServer")


### PR DESCRIPTION
Tested 2 hours ago:
chroot /var/lib/debootstrap/install/D7-J.1.4.0/openstack-common apt-get install -y --force-yes td-agent rsyslog-gnutls rsyslog-relp
Reading package lists... Done
Building dependency tree  
Reading state information... Done
The following extra packages will be installed:
  librelp0
Suggested packages:
  gnutls-bin
The following NEW packages will be installed:
  librelp0 rsyslog-gnutls rsyslog-relp td-agent
0 upgraded, 4 newly installed, 0 to remove and 16 not upgraded.

Please note that os-ci-admin.ring.enovance.com matches a private enovance IP which cannot be reached from people outside your organization ;)
